### PR TITLE
feat(preview): support configurable Compose preview annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ symbolCraft {
 
     // Preview generation configuration (optional)
     generatePreview.set(true)  // Enable preview generation
+    previewAnnotationClass.set("androidx.compose.ui.tooling.preview.Preview")  // Default
 
     // Icon naming configuration (optional)
     naming {
@@ -200,7 +201,58 @@ symbolCraft {
 
 ### Generated preview files
 
-The plugin generates preview functions for your icons using the `svg-to-compose` library's preview generation feature. The exact format depends on your project setup and the library version.
+The plugin generates preview functions for your icons using the `svg-to-compose` library's preview generation feature. SymbolCraft normalizes generated preview annotations to `androidx.compose.ui.tooling.preview.Preview` by default, matching the unified Compose Multiplatform preview annotation.
+
+### Preview annotation by Compose Multiplatform version
+
+For Compose Multiplatform 1.10+ projects, including the example app's Compose Multiplatform 1.11.1 setup, use the default AndroidX preview annotation:
+
+```kotlin
+// commonMain source code
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+fun IconPreview() {
+    // Preview content
+}
+```
+
+```kotlin
+symbolCraft {
+    generatePreview.set(true)
+    // Default: androidx.compose.ui.tooling.preview.Preview
+}
+```
+
+For Compose Multiplatform 1.9.x and older projects, keep using the JetBrains preview annotation explicitly:
+
+```kotlin
+// commonMain source code
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+fun IconPreview() {
+    // Preview content
+}
+```
+
+```kotlin
+symbolCraft {
+    generatePreview.set(true)
+    previewAnnotationClass.set("org.jetbrains.compose.ui.tooling.preview.Preview")
+}
+```
+
+For a project-specific wrapper annotation, configure its fully qualified class name:
+
+```kotlin
+symbolCraft {
+    generatePreview.set(true)
+    previewAnnotationClass.set("com.yourcompany.preview.IconPreview")
+}
+```
 
 ### View previews in IDE
 
@@ -212,10 +264,7 @@ After generation, you can view previews in Android Studio or IntelliJ IDEA's Pre
 
 ### Multi-platform preview support
 
-The preview generation is handled by the underlying `svg-to-compose` library and supports:
-- **Android projects**: Using `androidx.compose.ui.tooling.preview.Preview`
-- **Desktop projects**: Using `androidx.compose.desktop.ui.tooling.preview.Preview`
-- **Multiplatform projects**: Depending on the library configuration
+By default, generated previews use `androidx.compose.ui.tooling.preview.Preview`, which is available from common source sets in modern Compose Multiplatform projects. If you still target an older Compose Multiplatform version, set `previewAnnotationClass` to the annotation your project provides.
 
 ## 📋 Configuration Options
 
@@ -235,6 +284,7 @@ symbolCraft {
 
     // Preview configuration
     generatePreview.set(false)  // Default: false - Whether to generate Compose @Preview functions
+    previewAnnotationClass.set("androidx.compose.ui.tooling.preview.Preview")  // Default preview annotation
 
     // Download retry configuration
     maxRetries.set(3)  // Default: 3 - Maximum number of retry attempts for failed downloads

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -54,6 +54,7 @@ symbolCraft {
 
     // 预览生成配置（可选）
     generatePreview.set(true)  // 启用预览生成
+    previewAnnotationClass.set("androidx.compose.ui.tooling.preview.Preview")  // 默认值
 
     // 图标命名配置（可选）
     naming {
@@ -201,7 +202,58 @@ symbolCraft {
 
 ### 生成的预览文件
 
-插件使用 `svg-to-compose` 库的预览生成功能为你的图标生成预览函数。具体格式取决于你的项目设置和库版本。
+插件使用 `svg-to-compose` 库的预览生成功能为你的图标生成预览函数。SymbolCraft 默认会把生成的预览注解规范化为 `androidx.compose.ui.tooling.preview.Preview`，匹配 Compose Multiplatform 统一预览注解。
+
+### 不同 Compose Multiplatform 版本的 Preview 注解
+
+Compose Multiplatform 1.10+ 项目，包括示例项目当前使用的 Compose Multiplatform 1.11.1，直接使用默认 AndroidX 预览注解：
+
+```kotlin
+// commonMain 源码
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+fun IconPreview() {
+    // 预览内容
+}
+```
+
+```kotlin
+symbolCraft {
+    generatePreview.set(true)
+    // 默认：androidx.compose.ui.tooling.preview.Preview
+}
+```
+
+Compose Multiplatform 1.9.x 及更旧项目，请显式保留 JetBrains 旧预览注解：
+
+```kotlin
+// commonMain 源码
+import org.jetbrains.compose.ui.tooling.preview.Preview
+
+@Preview
+@Composable
+fun IconPreview() {
+    // 预览内容
+}
+```
+
+```kotlin
+symbolCraft {
+    generatePreview.set(true)
+    previewAnnotationClass.set("org.jetbrains.compose.ui.tooling.preview.Preview")
+}
+```
+
+如果你使用项目内自定义预览注解，可以配置完整注解类名：
+
+```kotlin
+symbolCraft {
+    generatePreview.set(true)
+    previewAnnotationClass.set("com.yourcompany.preview.IconPreview")
+}
+```
 
 ### 在 IDE 中查看预览
 
@@ -213,10 +265,7 @@ symbolCraft {
 
 ### 多平台预览支持
 
-预览生成由底层的 `svg-to-compose` 库处理，支持：
-- **Android 项目**: 使用 `androidx.compose.ui.tooling.preview.Preview`
-- **Desktop 项目**: 使用 `androidx.compose.desktop.ui.tooling.preview.Preview`
-- **多平台项目**: 根据库配置决定
+默认生成的预览使用 `androidx.compose.ui.tooling.preview.Preview`，现代 Compose Multiplatform 项目可以在 common source set 中使用它。如果你仍面向较旧的 Compose Multiplatform 版本，请将 `previewAnnotationClass` 设置为项目实际提供的注解。
 
 ## 📋 配置选项
 
@@ -236,6 +285,7 @@ symbolCraft {
 
     // 预览配置
     generatePreview.set(false)  // 默认：false - 是否生成 Compose @Preview 函数
+    previewAnnotationClass.set("androidx.compose.ui.tooling.preview.Preview")  // 默认预览注解
 
     // 下载重试配置
     maxRetries.set(3)  // 默认：3 - 下载失败时的最大重试次数

--- a/example/README.md
+++ b/example/README.md
@@ -12,6 +12,12 @@ This example showcases:
 - **Compose Preview**: Generated preview functions for all icons
 - **Modern configuration**: Using the latest SymbolCraft DSL features
 
+## Version Baseline
+
+- **Compose Multiplatform**: 1.11.1
+- **Kotlin**: 2.3.21
+- **Preview annotation**: `androidx.compose.ui.tooling.preview.Preview`
+
 ## Project Structure
 
 ```

--- a/example/composeApp/build.gradle.kts
+++ b/example/composeApp/build.gradle.kts
@@ -33,17 +33,17 @@ kotlin {
     
     sourceSets {
         androidMain.dependencies {
-            implementation(compose.preview)
-            implementation(compose.uiTooling)
+            implementation(libs.compose.ui.tooling.preview)
+            implementation(libs.compose.ui.tooling)
             implementation(libs.androidx.activity.compose)
         }
         commonMain.dependencies {
-            implementation(compose.runtime)
-            implementation(compose.foundation)
-            implementation(compose.material3)
-            implementation(compose.ui)
-            implementation(compose.components.resources)
-            implementation(compose.components.uiToolingPreview)
+            implementation(libs.compose.runtime)
+            implementation(libs.compose.foundation)
+            implementation(libs.compose.material3)
+            implementation(libs.compose.ui)
+            implementation(libs.compose.components.resources)
+            implementation(libs.compose.ui.tooling.preview)
             implementation(libs.androidx.lifecycle.viewmodelCompose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
         }
@@ -124,7 +124,7 @@ symbolCraft {
 
     // External icons with multiple style variants using the new styleParam API
     externalIcons(*listOf("home", "search", "person", "settings", "arrow_back").toTypedArray(), libraryName = "official") {
-        urlTemplate = "https://rawcdn.githack.com/google/material-design-icons/master/symbols/web/{name}/materialsymbolsrounded/{name}{fill}_24px.svg?min=1"
+        urlTemplate = "https://raw.githubusercontent.com/google/material-design-icons/master/symbols/web/{name}/materialsymbolsrounded/{name}{fill}_24px.svg"
         styleParam("fill") {
             values("", "_fill1")  // unfilled, filled variants
         }

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/local-test/icons/TelephoneSvgrepoCom.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/local-test/icons/TelephoneSvgrepoCom.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.`local-test`.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.TelephoneSvgrepoCom: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/local-test/icons/TestSvgsPenSvgrepoCom.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/local-test/icons/TestSvgsPenSvgrepoCom.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.`local-test`.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.TestSvgsPenSvgrepoCom: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/HomeW400Outlined.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/HomeW400Outlined.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.HomeW400Outlined: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/HomeW400Outlinedfill1.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/HomeW400Outlinedfill1.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.HomeW400Outlinedfill1: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/HomeW400Rounded.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/HomeW400Rounded.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.HomeW400Rounded: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/HomeW500Rounded.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/HomeW500Rounded.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.HomeW500Rounded: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/PersonW500Outlined.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/PersonW500Outlined.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.PersonW500Outlined: ImageVector
     get() {
@@ -24,8 +24,7 @@ public val Icons.PersonW500Outlined: ImageVector
         }
         _personW500Outlined = Builder(name = "PersonW500Outlined", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp, viewportWidth = 960.0f, viewportHeight = 960.0f).apply {
             path(fill = SolidColor(Color(0xFF000000)), stroke = null, strokeLineWidth = 0.0f, strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f, pathFillType = NonZero) {
-                moveTo(480.0f, 475.93f)
-                quadToRelative(-69.59f, 0.0f, -118.86f, -49.27f)
+                moveTo(361.14f, 426.66f)
                 quadToRelative(-49.27f, -49.27f, -49.27f, -118.86f)
                 quadToRelative(0.0f, -69.58f, 49.27f, -118.74f)
                 quadToRelative(49.27f, -49.15f, 118.86f, -49.15f)
@@ -33,6 +32,7 @@ public val Icons.PersonW500Outlined: ImageVector
                 quadToRelative(49.27f, 49.16f, 49.27f, 118.74f)
                 quadToRelative(0.0f, 69.59f, -49.27f, 118.86f)
                 quadToRelative(-49.27f, 49.27f, -118.86f, 49.27f)
+                reflectiveQuadToRelative(-118.86f, -49.27f)
                 close()
                 moveTo(151.87f, 812.2f)
                 verticalLineToRelative(-120.61f)
@@ -60,15 +60,15 @@ public val Icons.PersonW500Outlined: ImageVector
                 quadToRelative(-5.5f, 8.81f, -5.5f, 19.58f)
                 verticalLineToRelative(28.42f)
                 close()
-                moveTo(479.99f, 384.93f)
-                quadToRelative(31.81f, 0.0f, 54.48f, -22.65f)
+                moveTo(534.47f, 362.28f)
                 quadToRelative(22.66f, -22.65f, 22.66f, -54.47f)
                 quadToRelative(0.0f, -31.81f, -22.65f, -54.35f)
                 quadToRelative(-22.66f, -22.55f, -54.47f, -22.55f)
-                reflectiveQuadToRelative(-54.48f, 22.59f)
-                quadToRelative(-22.66f, 22.59f, -22.66f, 54.3f)
-                quadToRelative(0.0f, 31.82f, 22.65f, 54.48f)
+                reflectiveQuadToRelative(-54.48f, 22.55f)
+                quadToRelative(-22.66f, 22.54f, -22.66f, 54.35f)
+                quadToRelative(0.0f, 31.82f, 22.65f, 54.47f)
                 quadToRelative(22.66f, 22.65f, 54.47f, 22.65f)
+                reflectiveQuadToRelative(54.48f, -22.65f)
                 close()
                 moveTo(480.0f, 307.8f)
                 close()

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/PersonW500Rounded.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/PersonW500Rounded.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.PersonW500Rounded: ImageVector
     get() {
@@ -24,8 +24,7 @@ public val Icons.PersonW500Rounded: ImageVector
         }
         _personW500Rounded = Builder(name = "PersonW500Rounded", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp, viewportWidth = 960.0f, viewportHeight = 960.0f).apply {
             path(fill = SolidColor(Color(0xFF000000)), stroke = null, strokeLineWidth = 0.0f, strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f, pathFillType = NonZero) {
-                moveTo(480.0f, 475.93f)
-                quadToRelative(-69.59f, 0.0f, -118.86f, -49.27f)
+                moveTo(361.14f, 426.66f)
                 quadToRelative(-49.27f, -49.27f, -49.27f, -118.86f)
                 quadToRelative(0.0f, -69.58f, 49.27f, -118.74f)
                 quadToRelative(49.27f, -49.15f, 118.86f, -49.15f)
@@ -33,6 +32,7 @@ public val Icons.PersonW500Rounded: ImageVector
                 quadToRelative(49.27f, 49.16f, 49.27f, 118.74f)
                 quadToRelative(0.0f, 69.59f, -49.27f, 118.86f)
                 quadToRelative(-49.27f, 49.27f, -118.86f, 49.27f)
+                reflectiveQuadToRelative(-118.86f, -49.27f)
                 close()
                 moveTo(151.87f, 721.2f)
                 verticalLineToRelative(-29.61f)
@@ -64,15 +64,15 @@ public val Icons.PersonW500Rounded: ImageVector
                 quadToRelative(-5.5f, 8.81f, -5.5f, 19.58f)
                 verticalLineToRelative(28.42f)
                 close()
-                moveTo(479.99f, 384.93f)
-                quadToRelative(31.81f, 0.0f, 54.48f, -22.65f)
+                moveTo(534.47f, 362.28f)
                 quadToRelative(22.66f, -22.65f, 22.66f, -54.47f)
                 quadToRelative(0.0f, -31.81f, -22.65f, -54.35f)
                 quadToRelative(-22.66f, -22.55f, -54.47f, -22.55f)
-                reflectiveQuadToRelative(-54.48f, 22.59f)
-                quadToRelative(-22.66f, 22.59f, -22.66f, 54.3f)
-                quadToRelative(0.0f, 31.82f, 22.65f, 54.48f)
+                reflectiveQuadToRelative(-54.48f, 22.55f)
+                quadToRelative(-22.66f, 22.54f, -22.66f, 54.35f)
+                quadToRelative(0.0f, 31.82f, 22.65f, 54.47f)
                 quadToRelative(22.66f, 22.65f, 54.47f, 22.65f)
+                reflectiveQuadToRelative(54.48f, -22.65f)
                 close()
                 moveTo(480.0f, 307.8f)
                 close()

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/PersonW500Sharp.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/PersonW500Sharp.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.PersonW500Sharp: ImageVector
     get() {
@@ -24,8 +24,7 @@ public val Icons.PersonW500Sharp: ImageVector
         }
         _personW500Sharp = Builder(name = "PersonW500Sharp", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp, viewportWidth = 960.0f, viewportHeight = 960.0f).apply {
             path(fill = SolidColor(Color(0xFF000000)), stroke = null, strokeLineWidth = 0.0f, strokeLineCap = Butt, strokeLineJoin = Miter, strokeLineMiter = 4.0f, pathFillType = NonZero) {
-                moveTo(480.0f, 475.93f)
-                quadToRelative(-69.59f, 0.0f, -118.86f, -49.27f)
+                moveTo(361.14f, 426.66f)
                 quadToRelative(-49.27f, -49.27f, -49.27f, -118.86f)
                 quadToRelative(0.0f, -69.58f, 49.27f, -118.74f)
                 quadToRelative(49.27f, -49.15f, 118.86f, -49.15f)
@@ -33,6 +32,7 @@ public val Icons.PersonW500Sharp: ImageVector
                 quadToRelative(49.27f, 49.16f, 49.27f, 118.74f)
                 quadToRelative(0.0f, 69.59f, -49.27f, 118.86f)
                 quadToRelative(-49.27f, 49.27f, -118.86f, 49.27f)
+                reflectiveQuadToRelative(-118.86f, -49.27f)
                 close()
                 moveTo(151.87f, 812.2f)
                 verticalLineToRelative(-120.61f)
@@ -60,15 +60,15 @@ public val Icons.PersonW500Sharp: ImageVector
                 quadToRelative(-5.5f, 8.81f, -5.5f, 19.58f)
                 verticalLineToRelative(28.42f)
                 close()
-                moveTo(479.99f, 384.93f)
-                quadToRelative(31.81f, 0.0f, 54.48f, -22.65f)
+                moveTo(534.47f, 362.28f)
                 quadToRelative(22.66f, -22.65f, 22.66f, -54.47f)
                 quadToRelative(0.0f, -31.81f, -22.65f, -54.35f)
                 quadToRelative(-22.66f, -22.55f, -54.47f, -22.55f)
-                reflectiveQuadToRelative(-54.48f, 22.59f)
-                quadToRelative(-22.66f, 22.59f, -22.66f, 54.3f)
-                quadToRelative(0.0f, 31.82f, 22.65f, 54.48f)
+                reflectiveQuadToRelative(-54.48f, 22.55f)
+                quadToRelative(-22.66f, 22.54f, -22.66f, 54.35f)
+                quadToRelative(0.0f, 31.82f, 22.65f, 54.47f)
                 quadToRelative(22.66f, 22.65f, 54.47f, 22.65f)
+                reflectiveQuadToRelative(54.48f, -22.65f)
                 close()
                 moveTo(480.0f, 307.8f)
                 close()

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SearchW400Outlined.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SearchW400Outlined.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SearchW400Outlined: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SearchW500Outlined.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SearchW500Outlined.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SearchW500Outlined: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SearchW700Outlined.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SearchW700Outlined.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SearchW700Outlined: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SettingsW400Outlined.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SettingsW400Outlined.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SettingsW400Outlined: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SettingsW500Roundedfill1.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/materialsymbols/icons/SettingsW500Roundedfill1.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.materialsymbols.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SettingsW500Roundedfill1: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/mdi/icons/AbTestingMdi.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/mdi/icons/AbTestingMdi.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.mdi.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.AbTestingMdi: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/mdi/icons/AbacusMdi.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/mdi/icons/AbacusMdi.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.mdi.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.AbacusMdi: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/ArrowBackFill1.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/ArrowBackFill1.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.ArrowBackFill1: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/ArrowBackOfficial.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/ArrowBackOfficial.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.ArrowBackOfficial: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/HomeFill1.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/HomeFill1.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.HomeFill1: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/HomeOfficial.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/HomeOfficial.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.HomeOfficial: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/PersonFill1.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/PersonFill1.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.PersonFill1: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/PersonOfficial.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/PersonOfficial.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.PersonOfficial: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/SearchFill1.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/SearchFill1.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SearchFill1: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/SearchOfficial.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/SearchOfficial.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SearchOfficial: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/SettingsFill1.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/SettingsFill1.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SettingsFill1: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/SettingsOfficial.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/official/icons/SettingsOfficial.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.official.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.SettingsOfficial: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/simple-icons/icons/GithubSimpleIcons.kt
+++ b/example/composeApp/src/commonMain/kotlin/generated/symbols/io/github/kingsword09/example/icons/simple-icons/icons/GithubSimpleIcons.kt
@@ -13,9 +13,9 @@ import androidx.compose.ui.graphics.StrokeJoin.Companion.Miter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.graphics.vector.ImageVector.Builder
 import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.github.kingsword09.example.icons.`simple-icons`.Icons
-import org.jetbrains.compose.ui.tooling.preview.Preview
 
 public val Icons.GithubSimpleIcons: ImageVector
     get() {

--- a/example/composeApp/src/commonMain/kotlin/io/github/kingsword09/example/App.kt
+++ b/example/composeApp/src/commonMain/kotlin/io/github/kingsword09/example/App.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import org.jetbrains.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.Preview
 
 import io.github.kingsword09.example.icons.materialsymbols.Icons as MaterialSymbols
 import io.github.kingsword09.example.icons.materialsymbols.icons.HomeW400Rounded

--- a/example/gradle/libs.versions.toml
+++ b/example/gradle/libs.versions.toml
@@ -10,9 +10,10 @@ androidx-espresso = "3.7.0"
 androidx-lifecycle = "2.9.4"
 androidx-testExt = "1.3.0"
 composeHotReload = "1.0.0-beta07"
-composeMultiplatform = "1.9.0"
+composeMaterial3 = "1.11.0-alpha07"
+composeMultiplatform = "1.11.1"
 junit = "4.13.2"
-kotlin = "2.2.20"
+kotlin = "2.3.21"
 kotlinx-coroutines = "1.10.2"
 
 symbolcraft = "0.3.4"
@@ -21,6 +22,13 @@ symbolcraft = "0.3.4"
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 junit = { module = "junit:junit", version.ref = "junit" }
+compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
+compose-foundation = { module = "org.jetbrains.compose.foundation:foundation", version.ref = "composeMultiplatform" }
+compose-material3 = { module = "org.jetbrains.compose.material3:material3", version.ref = "composeMaterial3" }
+compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeMultiplatform" }
+compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
+compose-ui-tooling = { module = "org.jetbrains.compose.ui:ui-tooling", version.ref = "composeMultiplatform" }
+compose-ui-tooling-preview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
 androidx-testExt-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-testExt" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }

--- a/src/main/kotlin/io/github/kingsword09/symbolcraft/SymbolCraftDefaults.kt
+++ b/src/main/kotlin/io/github/kingsword09/symbolcraft/SymbolCraftDefaults.kt
@@ -1,0 +1,6 @@
+package io.github.kingsword09.symbolcraft
+
+/** Default values shared by the SymbolCraft DSL and generation pipeline. */
+object SymbolCraftDefaults {
+    const val PREVIEW_ANNOTATION_CLASS = "androidx.compose.ui.tooling.preview.Preview"
+}

--- a/src/main/kotlin/io/github/kingsword09/symbolcraft/converter/Svg2ComposeConverter.kt
+++ b/src/main/kotlin/io/github/kingsword09/symbolcraft/converter/Svg2ComposeConverter.kt
@@ -2,6 +2,7 @@ package io.github.kingsword09.symbolcraft.converter
 
 import io.github.kingsword09.svg2compose.Svg2Compose
 import io.github.kingsword09.svg2compose.VectorType
+import io.github.kingsword09.symbolcraft.SymbolCraftDefaults
 import java.io.File
 import java.util.Locale
 
@@ -20,6 +21,7 @@ class Svg2ComposeConverter {
      * @param outputDirectory Directory where generated Kotlin files will be saved
      * @param packageName Package name for generated files
      * @param generatePreview Whether to generate Compose preview functions
+     * @param previewAnnotationClass Fully qualified annotation class used for generated previews
      * @param accessorName Name of the object that will contain all icons
      * @param allAssetsPropertyName Name of the property that contains all icons
      * @param librarySubdir Optional subdirectory name for organizing icons by library (e.g.,
@@ -32,6 +34,7 @@ class Svg2ComposeConverter {
         outputDirectory: File,
         packageName: String,
         generatePreview: Boolean = true,
+        previewAnnotationClass: String = SymbolCraftDefaults.PREVIEW_ANNOTATION_CLASS,
         accessorName: String = "GeneratedIcons",
         allAssetsPropertyName: String = "AllIcons",
         librarySubdir: String? = null,
@@ -72,7 +75,13 @@ class Svg2ComposeConverter {
         )
 
         // Post-process generated files to ensure deterministic output
-        makeOutputDeterministic(outputDirectory, packageName, librarySubdir)
+        makeOutputDeterministic(
+            outputDirectory,
+            packageName,
+            librarySubdir,
+            generatePreview,
+            previewAnnotationClass,
+        )
     }
 
     /**
@@ -143,6 +152,8 @@ class Svg2ComposeConverter {
         outputDirectory: File,
         packageName: String,
         librarySubdir: String? = null,
+        generatePreview: Boolean = true,
+        previewAnnotationClass: String = SymbolCraftDefaults.PREVIEW_ANNOTATION_CLASS,
     ) {
         val packagePath = packageName.replace('.', '/')
         val baseDir = File(outputDirectory, packagePath)
@@ -163,7 +174,12 @@ class Svg2ComposeConverter {
             .filter { it.isFile && it.extension == "kt" }
             .forEach { file ->
                 val content = file.readText()
-                val deterministicContent = makeDeterministic(content)
+                val deterministicContent =
+                    makeDeterministic(
+                        content = content,
+                        generatePreview = generatePreview,
+                        previewAnnotationClass = previewAnnotationClass,
+                    )
                 if (content != deterministicContent) {
                     file.writeText(deterministicContent)
                 }
@@ -171,7 +187,11 @@ class Svg2ComposeConverter {
     }
 
     /** Remove non-deterministic elements from generated code */
-    private fun makeDeterministic(content: String): String {
+    private fun makeDeterministic(
+        content: String,
+        generatePreview: Boolean,
+        previewAnnotationClass: String,
+    ): String {
         return content
             // Remove timestamp comments (common patterns)
             .replace(
@@ -197,8 +217,72 @@ class Svg2ComposeConverter {
                 val number = matchResult.groupValues[1].toDouble()
                 String.format(Locale.US, "%.2f", number) + "f"
             }
+            .let {
+                normalizePreviewAnnotation(
+                    content = it,
+                    generatePreview = generatePreview,
+                    previewAnnotationClass = previewAnnotationClass,
+                )
+            }
             // Sort imports for consistency
             .let { sortImportsIfNeeded(it) }
+    }
+
+    /**
+     * Normalizes preview imports emitted by svg-to-compose.
+     *
+     * Compose Multiplatform 1.10 recommends the AndroidX preview annotation in common source sets,
+     * while older projects may still need the JetBrains annotation. Keeping this as a
+     * generated-code post-process lets SymbolCraft support both without forking the converter
+     * dependency.
+     */
+    private fun normalizePreviewAnnotation(
+        content: String,
+        generatePreview: Boolean,
+        previewAnnotationClass: String,
+    ): String {
+        if (!generatePreview || !content.contains("@Preview")) return content
+
+        val annotationClass = previewAnnotationClass.trim()
+        require(annotationClass.matches(KOTLIN_QUALIFIED_NAME_REGEX)) {
+            "previewAnnotationClass must be a fully qualified Kotlin annotation class name. " +
+                "Got: '$previewAnnotationClass'"
+        }
+
+        val annotationName = annotationClass.substringAfterLast('.')
+        val withoutPreviewImports =
+            content
+                .lines()
+                .filterNot { line ->
+                    val importedClass = line.removePrefix("import ").trim()
+                    line.startsWith("import ") &&
+                        (importedClass in GENERATED_PREVIEW_IMPORTS ||
+                            importedClass == annotationClass)
+                }
+                .joinToString("\n")
+
+        val withAnnotationName =
+            withoutPreviewImports.replace(PREVIEW_ANNOTATION_REGEX, "@$annotationName")
+
+        return addImportIfMissing(withAnnotationName, annotationClass)
+    }
+
+    /** Adds an import after the existing import block, or immediately after the package line. */
+    private fun addImportIfMissing(content: String, qualifiedName: String): String {
+        if (content.lines().any { it == "import $qualifiedName" }) return content
+
+        val lines = content.lines().toMutableList()
+        val lastImportIndex = lines.indexOfLast { it.startsWith("import ") }
+        val packageLineIndex = lines.indexOfFirst { it.startsWith("package ") }
+        val insertIndex =
+            when {
+                lastImportIndex >= 0 -> lastImportIndex + 1
+                packageLineIndex >= 0 -> packageLineIndex + 1
+                else -> 0
+            }
+
+        lines.add(insertIndex, "import $qualifiedName")
+        return lines.joinToString("\n")
     }
 
     /** Sort imports for deterministic order */
@@ -221,5 +305,19 @@ class Svg2ComposeConverter {
         val afterImports = lines.subList(importsEndIndex + 1, lines.size)
 
         return (beforeImports + imports + afterImports).joinToString("\n")
+    }
+
+    private companion object {
+        private val GENERATED_PREVIEW_IMPORTS =
+            setOf(
+                "androidx.compose.ui.tooling.preview.Preview",
+                "androidx.compose.desktop.ui.tooling.preview.Preview",
+                "org.jetbrains.compose.ui.tooling.preview.Preview",
+            )
+
+        private val KOTLIN_QUALIFIED_NAME_REGEX =
+            Regex("[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)+")
+
+        private val PREVIEW_ANNOTATION_REGEX = Regex("(?m)^@Preview(?=\\s*(\\(|$))")
     }
 }

--- a/src/main/kotlin/io/github/kingsword09/symbolcraft/plugin/SymbolCraftExtension.kt
+++ b/src/main/kotlin/io/github/kingsword09/symbolcraft/plugin/SymbolCraftExtension.kt
@@ -1,5 +1,6 @@
 package io.github.kingsword09.symbolcraft.plugin
 
+import io.github.kingsword09.symbolcraft.SymbolCraftDefaults
 import io.github.kingsword09.symbolcraft.model.*
 import java.io.File
 import java.nio.file.FileSystems
@@ -22,6 +23,8 @@ import org.gradle.api.provider.Property
  * @property outputDirectory Kotlin source folder where generated code will be written.
  * @property packageName root package used for generated Kotlin types.
  * @property generatePreview toggles Compose preview function generation for each icon.
+ * @property previewAnnotationClass fully qualified Compose preview annotation used when previews
+ *   are generated.
  * @property maxRetries maximum number of retry attempts for failed downloads (default: 3).
  * @property retryDelayMs initial delay between retries in milliseconds (default: 1000ms).
  */
@@ -32,6 +35,7 @@ abstract class SymbolCraftExtension {
     abstract val outputDirectory: Property<String>
     abstract val packageName: Property<String>
     abstract val generatePreview: Property<Boolean>
+    abstract val previewAnnotationClass: Property<String>
     abstract val maxRetries: Property<Int>
     abstract val retryDelayMs: Property<Long>
     abstract val projectDirectory: Property<String>
@@ -53,6 +57,7 @@ abstract class SymbolCraftExtension {
         outputDirectory.convention("src/main/kotlin")
         packageName.convention("io.github.kingsword09.symbolcraft.symbols")
         generatePreview.convention(false)
+        previewAnnotationClass.convention(SymbolCraftDefaults.PREVIEW_ANNOTATION_CLASS)
         maxRetries.convention(3)
         retryDelayMs.convention(1000L)
         projectDirectory.convention("")
@@ -273,7 +278,7 @@ abstract class SymbolCraftExtension {
      */
     fun getConfigHash(): String {
         val configString = buildString {
-            append("version:2.0|")
+            append("version:3.0|")
 
             append("icons:")
             iconsConfig.toSortedMap().forEach { (name, configs) ->
@@ -286,6 +291,7 @@ abstract class SymbolCraftExtension {
             append("|package:").append(packageName.orNull)
             append("|outputDir:").append(outputDirectory.orNull)
             append("|preview:").append(generatePreview.orNull)
+            append("|previewAnnotationClass:").append(previewAnnotationClass.orNull)
             append("|namingConfig:").append(namingConfig.snapshotSignature())
         }
         return configString.hashCode().toString()

--- a/src/main/kotlin/io/github/kingsword09/symbolcraft/plugin/SymbolCraftPlugin.kt
+++ b/src/main/kotlin/io/github/kingsword09/symbolcraft/plugin/SymbolCraftPlugin.kt
@@ -31,6 +31,7 @@ class SymbolCraftPlugin : Plugin<Project> {
                 task.projectBuildDir.set(project.layout.buildDirectory.get().asFile.absolutePath)
                 task.inputs.property("symbolsConfig", extension.getConfigHash())
                 task.inputs.property("generatePreview", extension.generatePreview)
+                task.inputs.property("previewAnnotationClass", extension.previewAnnotationClass)
                 task.inputs.property("namingConfigSignature", extension.namingConfigSignature())
             }
 

--- a/src/main/kotlin/io/github/kingsword09/symbolcraft/tasks/internal/SvgConversionCoordinator.kt
+++ b/src/main/kotlin/io/github/kingsword09/symbolcraft/tasks/internal/SvgConversionCoordinator.kt
@@ -69,6 +69,7 @@ internal class SvgConversionCoordinator(
                     outputDirectory = context.outputDir,
                     packageName = context.packageName,
                     generatePreview = ext.generatePreview.get(),
+                    previewAnnotationClass = ext.previewAnnotationClass.get(),
                     accessorName = "Icons",
                     allAssetsPropertyName = "AllIcons",
                     librarySubdir = librarySubdir,

--- a/src/test/kotlin/io/github/kingsword09/symbolcraft/tasks/GenerateSymbolsTaskTest.kt
+++ b/src/test/kotlin/io/github/kingsword09/symbolcraft/tasks/GenerateSymbolsTaskTest.kt
@@ -113,6 +113,70 @@ class GenerateSymbolsTaskTest {
     }
 
     @Test
+    fun `generated previews default to unified android x preview annotation`() {
+        createSettings("symbolcraft-preview-default")
+        createBuildScript(
+            """
+                cacheEnabled.set(false)
+                generatePreview.set(true)
+                localIcons {
+                    directory = "src/icons"
+                }
+            """
+                .trimIndent()
+        )
+
+        writeSvg("src/icons/home.svg")
+
+        val result = runGradle("generateSymbolCraftIcons")
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateSymbolCraftIcons")?.outcome)
+
+        val iconContent = firstGeneratedIconContent("icons/local")
+        assertTrue(
+            iconContent.contains("import androidx.compose.ui.tooling.preview.Preview"),
+            iconContent,
+        )
+        assertTrue(
+            !iconContent.contains("import org.jetbrains.compose.ui.tooling.preview.Preview"),
+            iconContent,
+        )
+        assertTrue(iconContent.contains("\n@Preview\n"), iconContent)
+    }
+
+    @Test
+    fun `generated previews can use custom preview annotation class`() {
+        createSettings("symbolcraft-preview-custom")
+        createBuildScript(
+            """
+                cacheEnabled.set(false)
+                generatePreview.set(true)
+                previewAnnotationClass.set("com.test.preview.IconPreview")
+                localIcons {
+                    directory = "src/icons"
+                }
+            """
+                .trimIndent()
+        )
+
+        writeSvg("src/icons/home.svg")
+
+        val result = runGradle("generateSymbolCraftIcons")
+        assertEquals(TaskOutcome.SUCCESS, result.task(":generateSymbolCraftIcons")?.outcome)
+
+        val iconContent = firstGeneratedIconContent("icons/local")
+        assertTrue(iconContent.contains("import com.test.preview.IconPreview"), iconContent)
+        assertTrue(
+            !iconContent.contains("import androidx.compose.ui.tooling.preview.Preview"),
+            iconContent,
+        )
+        assertTrue(
+            !iconContent.contains("import org.jetbrains.compose.ui.tooling.preview.Preview"),
+            iconContent,
+        )
+        assertTrue(iconContent.contains("\n@IconPreview\n"), iconContent)
+    }
+
+    @Test
     fun `local and remote icons generate when remote svg is cached`() {
         createSettings("symbolcraft-mixed")
         createBuildScript(
@@ -236,6 +300,14 @@ class GenerateSymbolsTaskTest {
 
     private fun generatedDir(suffix: String): Path =
         projectDir.resolve("build/generated/symbols/com/test/symbols/$suffix")
+
+    private fun firstGeneratedIconContent(suffix: String): String {
+        val generatedIcon =
+            generatedDir(suffix).resolve("icons").toFile().walkTopDown().first {
+                it.isFile && it.extension == "kt"
+            }
+        return generatedIcon.toPath().readText()
+    }
 
     private fun writeProjectFile(relativePath: String, content: String) {
         val target = projectDir.resolve(relativePath)


### PR DESCRIPTION
  - add previewAnnotationClass DSL option with AndroidX Preview as default
  - normalize generated preview imports for modern Compose Multiplatform
  - document Preview usage for Compose Multiplatform 1.10+ and legacy versions
  - update example to Kotlin 2.3.21 and Compose Multiplatform 1.11.1
  - switch example official icon source to GitHub raw to avoid rawcdn 403 failures
  - refresh generated example icons